### PR TITLE
Fix compile errors on wasm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
         config:
           - { os: ubuntu-latest, target: 'x86_64-unknown-linux-gnu' }
           - { os: ubuntu-latest, target: 'x86_64-pc-windows-gnu' }
-          # - { os: ubuntu-latest, target: 'wasm32-unknown-unknown' }
+          - { os: ubuntu-latest, target: 'wasm32-unknown-unknown' }
           - { os: macos-latest, target: 'x86_64-apple-darwin' }
           - { os: macos-latest, target: 'aarch64-apple-ios' }
           - { os: macos-latest, target: 'x86_64-apple-ios' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "A lite, fully featured 2D game engine."
 repository = "https://github.com/Bombfuse/emerald"
 license = "MIT OR Apache-2.0"
+resolver = "2"
 
 [features]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -28,13 +29,15 @@ nalgebra =  { version = "0.26.2" }
 # Optionals
 rapier2d = { version = "0.8.0", default-features = false, features = [ "dim2", "f32" ], optional = true  }
 gamepad = { version = "0.1.1", optional = true }
-kira = { version= "0.5.2", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 miniquad = { version = "0.3.0-alpha.30", features = [ "log-impl" ] }
+# mp3 does not works on wasm :(
+kira = { version= "0.5.2", optional = true, default-features = false, features = ["ogg", "flac", "wav"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 miniquad = "0.3.0-alpha.30"
+kira = { version= "0.5.2", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 sapp-android = "0.1.8"

--- a/examples/gamepads.rs
+++ b/examples/gamepads.rs
@@ -17,7 +17,7 @@ impl Game for GamepadExample {
             emd.loader()
                 .pack_bytes(
                     "./examples/assets/bunny.png",
-                    include_bytes!("../assets/bunny.png").to_vec(),
+                    include_bytes!("./assets/bunny.png").to_vec(),
                 )
                 .unwrap();
         }

--- a/examples/labels.rs
+++ b/examples/labels.rs
@@ -15,7 +15,7 @@ impl Game for GamepadExample {
             emd.loader()
                 .pack_bytes(
                     "./examples/assets/Roboto-Light.ttf",
-                    include_bytes!("../assets/Roboto-Light.ttf").to_vec(),
+                    include_bytes!("./assets/Roboto-Light.ttf").to_vec(),
                 )
                 .unwrap();
         }

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -25,7 +25,7 @@ impl Game for MouseExample {
             emd.loader()
                 .pack_bytes(
                     "./examples/assets/bunny.png",
-                    include_bytes!("../assets/bunny.png").to_vec(),
+                    include_bytes!("./assets/bunny.png").to_vec(),
                 )
                 .unwrap();
         }

--- a/examples/physics_groups.rs
+++ b/examples/physics_groups.rs
@@ -43,7 +43,7 @@ impl Game for PhysicsGroupsExample {
             emd.loader()
                 .pack_bytes(
                     "./examples/assets/bunny.png",
-                    include_bytes!("../assets/bunny.png").to_vec(),
+                    include_bytes!("./assets/bunny.png").to_vec(),
                 )
                 .unwrap();
         }

--- a/src/assets/asset_loader.rs
+++ b/src/assets/asset_loader.rs
@@ -5,7 +5,7 @@ use crate::*;
 
 use std::ffi::OsStr;
 
-#[cfg(target_arch = "wasm")]
+#[cfg(target_arch = "wasm32")]
 fn read_file(path: &str) -> Result<Vec<u8>, EmeraldError> {
     Err(EmeraldError::new(format!(
         "Unable to get bytes for {}",


### PR DESCRIPTION
MP3 is disabled because `kira v0.5.3` uses `minimp3 v0.5.1` for decoding, but it depends on `slice-deque v0.3.0` that has following issue: https://github.com/gnzlbg/slice_deque/issues/86

Still not figured out how to run compiled wasm, but at least it compiles.