### PR TITLE
Add basic touch input support

### DIFF
--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -30,12 +30,11 @@ impl Game for MouseExample {
                 .unwrap();
         }
 
-        match emd.loader().sprite("./examples/assets/bunny.png") {
-            Ok(sprite) => {
-                emd.world().spawn((sprite, Position::new(16.0, 16.0)));
-            }
-            Err(_) => {}
-        };
+        if let Ok(sprite) = emd.loader().sprite("./examples/assets/bunny.png") {
+            emd.world().spawn((sprite, Position::new(16.0, 16.0)));
+        }
+        
+        emd.touches_to_mouse(true);
     }
 
     fn update(&mut self, mut emd: Emerald) {
@@ -83,7 +82,8 @@ impl Game for MouseExample {
     fn draw(&mut self, mut emd: Emerald) {
         emd.graphics().begin().unwrap();
 
-        emd.graphics().draw_color_rect(&self.background, &self.screen_center);
+        emd.graphics()
+            .draw_color_rect(&self.background, &self.screen_center);
         emd.graphics().draw_color_rect(&self.rect, &self.position);
 
         if let Some(mut world) = emd.pop_world() {

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+use emerald::*;
+
+pub fn main() {
+    let game = TouchExample {
+        bunnies: HashMap::new(),
+        sprite: None,
+    };
+    emerald::start(Box::new(game), GameSettings::default())
+}
+
+pub struct TouchExample {
+    bunnies: HashMap<u64, Entity>,
+    sprite: Option<Sprite>,
+}
+
+impl Game for TouchExample {
+    fn initialize(&mut self, mut emd: Emerald) {
+        // Pack all game files into WASM binary
+        #[cfg(target_arch = "wasm32")]
+        {
+            emd.loader()
+                .pack_bytes(
+                    "./examples/assets/bunny.png",
+                    include_bytes!("./assets/bunny.png").to_vec(),
+                )
+                .unwrap();
+        }
+
+        self.sprite = emd.loader().sprite("./examples/assets/bunny.png").ok();
+        emd.mouse_to_touch(true);
+    }
+
+    fn update(&mut self, mut emd: Emerald) {
+        let input = emd.input();
+        let touches = input.touches();
+
+        let screen = emd.screen_size();
+        let screen_center = Position::new(screen.0 / 2.0, screen.1 / 2.0);
+
+        for (&id, touch) in touches {
+            let bunny_position = touch.position - screen_center;
+            if touch.is_just_pressed() {
+                let components: (Sprite, Position) = (self.sprite.clone().unwrap(), bunny_position);
+                self.bunnies.insert(id, emd.world().spawn(components));
+            } else if touch.is_just_released() {
+                if let Some(x) = self.bunnies.remove(&id) {
+                    emd.world().despawn(x).unwrap();
+                }
+            } else {
+                let bunny = self
+                    .bunnies
+                    .get(&id)
+                    .copied()
+                    .and_then(|ent| emd.world().get_mut::<Position>(ent).ok());
+                if let Some(mut bunny) = bunny {
+                    *bunny = bunny_position;
+                }
+            }
+        }
+    }
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -129,6 +129,19 @@ impl<'a> Emerald<'a> {
     pub fn input(&mut self) -> InputHandler {
         InputHandler::new(&mut self.input_engine)
     }
+
+    /// Makes all touches also be registered as mouse events.
+    #[inline]
+    pub fn touches_to_mouse(&mut self, enabled: bool) {
+        self.input_engine.touches_to_mouse = enabled;
+    }
+
+    /// Makes mouse clicks treated as touch event.
+    #[inline]
+    pub fn mouse_to_touch(&mut self, enabled: bool) {
+        self.input_engine.mouse_to_touch = enabled;
+    }
+
     // ************************************* //
 
     // ************* World API ************* //

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -141,6 +141,12 @@ impl EventHandler for GameEngine {
     }
 
     #[inline]
+    fn touch_event(&mut self, ctx: &mut Context, phase: TouchPhase, id: u64, x: f32, y: f32) {
+        let y = ctx.screen_size().1 - y;
+        self.input_engine.touch_event(phase, id, x, y)
+    }
+
+    #[inline]
     fn draw(&mut self, mut ctx: &mut Context) {
         let start_of_frame = miniquad::date::now();
         let delta = start_of_frame - self.last_instant;

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,12 @@
 mod button_state;
 mod engine;
 mod handler;
-pub mod mouse_state;
+mod mouse_state;
+mod touch_state;
 
 pub use button_state::*;
+pub use mouse_state::*;
+pub use touch_state::*;
 pub(crate) use engine::*;
 pub use handler::*;
 pub use miniquad::KeyCode;

--- a/src/input/touch_state.rs
+++ b/src/input/touch_state.rs
@@ -1,0 +1,50 @@
+use miniquad::TouchPhase;
+
+use crate::Position;
+
+#[derive(Debug, Clone, Copy)]
+pub struct TouchState {
+    pub position: Position,
+    pub previous: TouchPhase,
+    pub phase: TouchPhase,
+}
+
+impl Default for TouchState {
+    fn default() -> Self {
+        TouchState {
+            position: Position::zero(),
+            previous: TouchPhase::Cancelled,
+            phase: TouchPhase::Cancelled,
+        }
+    }
+}
+
+impl TouchState {
+    #[inline]
+    pub fn was_pressed(&self) -> bool {
+        self.previous == TouchPhase::Started || self.previous == TouchPhase::Moved
+    }
+
+    #[inline]
+    pub fn is_pressed(&self) -> bool {
+        self.phase == TouchPhase::Started || self.phase == TouchPhase::Moved
+    }
+
+    #[inline]
+    pub fn is_just_pressed(&self) -> bool {
+        !self.was_pressed() && self.is_pressed()
+    }
+
+    #[inline]
+    pub fn is_just_released(&self) -> bool {
+        self.was_pressed() && !self.is_pressed()
+    }
+
+    pub(crate) fn is_outdated(&self) -> bool {
+        !self.was_pressed() && !self.is_pressed()
+    }
+
+    pub(crate) fn rollover(&mut self) {
+        self.previous = self.phase;
+    }
+}


### PR DESCRIPTION
No support for gestures, but at least it allows running mouse-oriented games on mobile devices by simply calling `touches_to_mouse` on `InputHandler`.