### PR TITLE
User and asset file pathing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 default = ["logging", "gamepads", "physics", "audio"]
 logging = ["miniquad/log-impl"]
-audio = ["kira"]
 physics = ["rapier2d"]
 gamepads = ["gamepad"]
 headless = []
+audio = ["kira"]
 
 [dependencies]
 image = { version = "0.23.14", default-features = false, features = [ "png" ] }
@@ -32,13 +32,11 @@ gamepad = { version = "0.1.1", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 miniquad = { version = "0.3.0-alpha.37", features = [ "log-impl" ] }
-# mp3 does not works on wasm :(
 kira = { version= "0.5.2", optional = true, default-features = false, features = ["ogg", "flac", "wav"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 miniquad = "0.3.0-alpha.37"
 kira = { version= "0.5.2", optional = true }
-
 
 [target.'cfg(target_os = "android")'.dependencies]
 sapp-android = "0.1.8"

--- a/examples/aseprite.rs
+++ b/examples/aseprite.rs
@@ -11,16 +11,28 @@ pub fn main() {
 pub struct MyGame;
 impl Game for MyGame {
     fn initialize(&mut self, mut emd: Emerald) {
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
+
         let mut aseprite = emd
             .loader()
             .aseprite_with_animations(
-                "./examples/assets/smiley.png",
-                "./examples/assets/smiley.json",
+                "smiley.png",
+                "smiley.json",
             )
             .unwrap();
 
         aseprite.play_and_loop("smile");
 
         emd.world().spawn((aseprite, Position::new(64.0, 64.0)));
+    }
+
+    fn update(&mut self, mut emd: Emerald) {
+        let world = emd.pop_world();
+        let delta = emd.delta();
+
+        if let Some(mut world) = world {
+            aseprite_update_system(&mut world, delta);
+            emd.push_world(world);
+        }
     }
 }

--- a/examples/audio.rs
+++ b/examples/audio.rs
@@ -16,21 +16,23 @@ pub fn main() {
 pub struct Example {
 }
 impl Game for Example {
-    fn initialize(&mut self, mut emd: Emerald) {}
+    fn initialize(&mut self, mut emd: Emerald) {
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
+    }
 
     fn update(&mut self, mut emd: Emerald) {
         let mut input = emd.input();
 
         let volume = emd.audio().mixer("test").unwrap().get_volume().unwrap();
         if input.is_key_just_pressed(KeyCode::A) {
-            emd.audio().mixer("test").unwrap().set_volume(volume - 0.1);
+            emd.audio().mixer("test").unwrap().set_volume(volume - 0.1).unwrap();
         } else if input.is_key_just_pressed(KeyCode::D) {
-            emd.audio().mixer("test").unwrap().set_volume(volume + 0.1);
+            emd.audio().mixer("test").unwrap().set_volume(volume + 0.1).unwrap();
         }
 
         if input.is_key_just_pressed(KeyCode::Space) {
             let snd = emd.loader()
-                .sound("./examples/assets/test_music.wav")
+                .sound("test_music.wav")
                 .unwrap();
             emd.audio().mixer("test").unwrap().play_and_loop(snd.clone()).unwrap();
         }
@@ -38,7 +40,7 @@ impl Game for Example {
         if input.is_key_just_pressed(KeyCode::Z) {
             for _ in 0..10 {
                 let snd = emd.loader()
-                    .sound("./examples/assets/test_sound.wav")
+                    .sound("test_sound.wav")
                     .unwrap();
                 emd.audio().mixer("test").unwrap().play(snd.clone()).unwrap();
             }
@@ -46,18 +48,13 @@ impl Game for Example {
     }
 
     fn draw(&mut self, mut emd: Emerald) {
-        emd.graphics().begin();
-        let font = emd.loader().font("./examples/assets/Roboto-Light.ttf", 48).unwrap();
+        emd.graphics().begin().unwrap();
+        let font = emd.loader().font("Roboto-Light.ttf", 48).unwrap();
         let volume = emd.audio().mixer("test").unwrap().get_volume().unwrap();
 
         let volume_label = Label::new(format!("Volume: {:05.2}", volume), font.clone(), 48);
-        let instructions_a = Label::new("A = -0.1", font.clone(), 48);
-        let instructions_b = Label::new("D = +0.1", font.clone(), 48);
-
         emd.graphics().draw_label(&volume_label, &Position::new(240.0, 180.0)).unwrap();
-        // emd.graphics().draw_label(&volume_label, &Position::new(240.0, 180.0)).unwrap();
-        // emd.graphics().draw_label(&volume_label, &Position::new(240.0, 180.0)).unwrap();
 
-        emd.graphics().render();
+        emd.graphics().render().unwrap();
     }
 }

--- a/examples/bunnymark.rs
+++ b/examples/bunnymark.rs
@@ -25,16 +25,9 @@ pub struct BunnymarkGame {
 }
 impl Game for BunnymarkGame {
     fn initialize(&mut self, mut emd: Emerald) {
-        // Pack all game files into WASM binary
-        #[cfg(target_arch = "wasm32")]
-        {
-            emd.loader().pack_bytes(
-                "./examples/assets/bunny.png",
-                include_bytes!("../examples/assets/bunny.png").to_vec(),
-            );
-        }
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
 
-        let sprite = emd.loader().sprite("./examples/assets/bunny.png").unwrap();
+        let sprite = emd.loader().sprite("bunny.png").unwrap();
 
         let mut position = Position::new(0.0, 0.0);
 
@@ -52,7 +45,7 @@ impl Game for BunnymarkGame {
         let sprite_width = 32.0;
 
         if emd.input().is_key_just_pressed(KeyCode::Space) {
-            let mut sprite = emd.loader().sprite("./examples/assets/bunny.png").unwrap();
+            let mut sprite = emd.loader().sprite("bunny.png").unwrap();
             sprite.offset = Vector2::new(-10.0, 0.0);
 
             let mut position = Position::new(0.0, 0.0);

--- a/examples/gamepads.rs
+++ b/examples/gamepads.rs
@@ -11,18 +11,9 @@ pub fn main() {
 pub struct GamepadExample;
 impl Game for GamepadExample {
     fn initialize(&mut self, mut emd: Emerald) {
-        // Pack all game files into WASM binary
-        #[cfg(target_arch = "wasm32")]
-        {
-            emd.loader()
-                .pack_bytes(
-                    "./examples/assets/bunny.png",
-                    include_bytes!("./assets/bunny.png").to_vec(),
-                )
-                .unwrap();
-        }
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
 
-        match emd.loader().sprite("./examples/assets/bunny.png") {
+        match emd.loader().sprite("bunny.png") {
             Ok(sprite) => {
                 emd.world().spawn((sprite, Position::new(16.0, 16.0)));
             }

--- a/examples/labels.rs
+++ b/examples/labels.rs
@@ -9,19 +9,11 @@ pub struct ElapsedTime(f32);
 pub struct GamepadExample;
 impl Game for GamepadExample {
     fn initialize(&mut self, mut emd: Emerald) {
-        // Pack all game files into WASM binary
-        #[cfg(target_arch = "wasm32")]
-        {
-            emd.loader()
-                .pack_bytes(
-                    "./examples/assets/Roboto-Light.ttf",
-                    include_bytes!("./assets/Roboto-Light.ttf").to_vec(),
-                )
-                .unwrap();
-        }
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
+
         let font = emd
             .loader()
-            .font("./examples/assets/Roboto-Light.ttf", 40)
+            .font("Roboto-Light.ttf", 40)
             .unwrap();
 
         let mut left_aligned_label = Label::new("Emerald Engine", font.clone(), 80);
@@ -65,17 +57,6 @@ impl Game for GamepadExample {
             } else if input.is_key_just_pressed(KeyCode::R) {
                 label.max_width = Some(400.0);
             }
-
-            // elapsed_time.0 = elapsed_time.0 + delta;
-
-            // if elapsed_time.0 >= 0.5 {
-            //     elapsed_time.0 = 0.0;
-            //     label.visible_characters += 1;
-
-            //     if label.visible_characters > label.text.len() as i64 {
-            //         label.visible_characters = 0;
-            //     }
-            // }
         }
     }
 }

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -19,18 +19,9 @@ pub struct MouseExample {
 
 impl Game for MouseExample {
     fn initialize(&mut self, mut emd: Emerald) {
-        // Pack all game files into WASM binary
-        #[cfg(target_arch = "wasm32")]
-        {
-            emd.loader()
-                .pack_bytes(
-                    "./examples/assets/bunny.png",
-                    include_bytes!("./assets/bunny.png").to_vec(),
-                )
-                .unwrap();
-        }
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
 
-        if let Ok(sprite) = emd.loader().sprite("./examples/assets/bunny.png") {
+        if let Ok(sprite) = emd.loader().sprite("bunny.png") {
             emd.world().spawn((sprite, Position::new(16.0, 16.0)));
         }
         

--- a/examples/physics.rs
+++ b/examples/physics.rs
@@ -59,7 +59,7 @@ impl MyGame {
         collider_builder: ColliderBuilder,
         velocity: Velocity,
     ) {
-        let sprite = emd.loader().sprite("./examples/assets/bunny.png").unwrap();
+        let sprite = emd.loader().sprite("bunny.png").unwrap();
         let entity = emd.world().spawn((sprite, position));
         let body = emd
             .world()
@@ -74,19 +74,7 @@ impl MyGame {
 }
 impl Game for MyGame {
     fn initialize(&mut self, mut emd: Emerald) {
-        // Pack all game files into WASM binary
-        emd.loader()
-            .pack_bytes(
-                "./examples/assets/bunny.png",
-                include_bytes!("./assets/bunny.png").to_vec(),
-            )
-            .unwrap();
-        emd.loader()
-            .pack_bytes(
-                "./examples/assets/Roboto-Light.ttf",
-                include_bytes!("./assets/Roboto-Light.ttf").to_vec(),
-            )
-            .unwrap();
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
 
         let borders = vec![
             (
@@ -173,7 +161,7 @@ impl Game for MyGame {
     }
 
     fn draw(&mut self, mut emd: Emerald) {
-        emd.graphics().begin();
+        emd.graphics().begin().unwrap();
 
         if let Some(mut world) = emd.pop_world() {
             emd.graphics().draw_world(&mut world).unwrap();
@@ -184,7 +172,7 @@ impl Game for MyGame {
             let fps = emd.fps() as u8;
             let font = emd
                 .loader()
-                .font("./examples/assets/Roboto-Light.ttf", 48)
+                .font("Roboto-Light.ttf", 48)
                 .unwrap();
             let mut label = Label::new(format!("FPS: {}", fps), font, 24);
             label.centered = false;
@@ -192,6 +180,6 @@ impl Game for MyGame {
                 .draw_label(&label, &Position::new(24.0, RES_HEIGHT as f32 - 10.0)).unwrap();
         }
         // emd.graphics().draw_colliders(Color::new(255, 0, 0, 130));
-        emd.graphics().render();
+        emd.graphics().render().unwrap();
     }
 }

--- a/examples/physics_groups.rs
+++ b/examples/physics_groups.rs
@@ -37,16 +37,7 @@ pub struct PhysicsGroupsExample {
 }
 impl Game for PhysicsGroupsExample {
     fn initialize(&mut self, mut emd: Emerald) {
-        // Pack all game files into WASM binary
-        #[cfg(target_arch = "wasm32")]
-        {
-            emd.loader()
-                .pack_bytes(
-                    "./examples/assets/bunny.png",
-                    include_bytes!("./assets/bunny.png").to_vec(),
-                )
-                .unwrap();
-        }
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
 
         let (entity1, body1) = emd
             .world()

--- a/examples/render_to_texture.rs
+++ b/examples/render_to_texture.rs
@@ -19,6 +19,8 @@ pub struct MyGame {
 }
 impl Game for MyGame {
     fn initialize(&mut self, mut emd: Emerald) {
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
+
         self.render_texture = Some(emd.loader().render_texture(RES_WIDTH as usize, RES_HEIGHT as usize).unwrap());
     }
 
@@ -56,9 +58,9 @@ impl Game for MyGame {
 
     fn draw(&mut self, mut emd: Emerald) {
         let now = std::time::Instant::now();
-        emd.graphics().begin_texture(self.render_texture.as_ref().unwrap().clone());
+        emd.graphics().begin_texture(self.render_texture.as_ref().unwrap().clone()).unwrap();
 
-        let rabbit = emd.loader().sprite("./examples/assets/bunny.png").unwrap();
+        let rabbit = emd.loader().sprite("bunny.png").unwrap();
         emd.graphics().draw_color_rect(&ColorRect::new(WHITE, 500 * 500, 500 * 500),
         &Position::new((RES_WIDTH / 2) as f32, (RES_HEIGHT / 2) as f32));
         emd.graphics().draw_sprite(&rabbit, &Position::new((RES_WIDTH / 2) as f32, (RES_HEIGHT / 2) as f32));
@@ -77,9 +79,9 @@ impl Game for MyGame {
         screen_sprite.scale.x = self.scale;
         screen_sprite.scale.y = self.scale;
 
-        emd.graphics().begin();
+        emd.graphics().begin().unwrap();
         emd.graphics().draw_sprite(&screen_sprite, &self.pos);
-        emd.graphics().render();
+        emd.graphics().render().unwrap();
 
         println!("screen draw: {:?}", e - now);
     }

--- a/examples/sprites.rs
+++ b/examples/sprites.rs
@@ -1,0 +1,35 @@
+use emerald::*;
+
+pub fn main() {
+    emerald::start(Box::new(SpritesExample { world: None }), GameSettings::default())
+}
+
+pub struct SpritesExample {
+    world: Option<EmeraldWorld>,
+}
+impl Game for SpritesExample {
+    fn initialize(&mut self, mut emd: Emerald) {
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
+        let sprite = emd.loader().sprite("bunny.png").unwrap();
+        self.world = Some(EmeraldWorld::new());
+        
+        if let Some(world) = &mut self.world {
+            world.spawn((sprite, Position::zero()));
+        }
+    }
+
+    fn update(&mut self, _emd: Emerald) {
+
+
+    }
+
+    fn draw(&mut self, mut emd: Emerald) {
+        emd.graphics().begin().unwrap();
+
+        if let Some(world) = &mut self.world {
+            emd.graphics().draw_world(world).unwrap();
+        } 
+
+        emd.graphics().render().unwrap();
+    }
+}

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -17,18 +17,8 @@ pub struct TouchExample {
 
 impl Game for TouchExample {
     fn initialize(&mut self, mut emd: Emerald) {
-        // Pack all game files into WASM binary
-        #[cfg(target_arch = "wasm32")]
-        {
-            emd.loader()
-                .pack_bytes(
-                    "./examples/assets/bunny.png",
-                    include_bytes!("./assets/bunny.png").to_vec(),
-                )
-                .unwrap();
-        }
-
-        self.sprite = emd.loader().sprite("./examples/assets/bunny.png").ok();
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
+        self.sprite = emd.loader().sprite("bunny.png").ok();
         emd.mouse_to_touch(true);
     }
 

--- a/src/assets/asset_store.rs
+++ b/src/assets/asset_store.rs
@@ -4,8 +4,17 @@ use crate::rendering::*;
 use miniquad::Context;
 use std::collections::HashMap;
 
+
+
 const INITIAL_TEXTURE_STORAGE_CAPACITY: usize = 100;
 const INITIAL_FONT_STORAGE_CAPACITY: usize = 100;
+
+const DEFAULT_ASSET_FOLDER: &str = "./assets";
+
+/// Default to storing user data in the application directory.
+/// Note: This will destroy any user/save files if the game is re-installed.
+const DEFAULT_USER_DATA_FOLDER: &str = "./";
+
 // const INITIAL_SOUND_STORAGE_CAPACITY: usize = 100;
 
 /// The AssetStore stores all Textures, Fonts, and Audio for the game.
@@ -13,17 +22,19 @@ const INITIAL_FONT_STORAGE_CAPACITY: usize = 100;
 /// Assets can be loaded via the `AssetLoader` and inserted into the AssetStore.
 /// Assets can be manually removed from the store if memory management becomes a concern.
 pub(crate) struct AssetStore {
-    pub bytes: HashMap<String, Vec<u8>>,
+    bytes: HashMap<String, Vec<u8>>,
 
-    pub fonts: Vec<Font>,
-    pub fontdue_fonts: Vec<fontdue::Font>,
-    pub textures: Vec<Texture>,
+    fonts: Vec<Font>,
+    fontdue_fonts: Vec<fontdue::Font>,
+    textures: Vec<Texture>,
 
-    pub fontdue_key_map: HashMap<FontKey, usize>,
-    pub font_key_map: HashMap<FontKey, usize>,
+    fontdue_key_map: HashMap<FontKey, usize>,
+    font_key_map: HashMap<FontKey, usize>,
     pub texture_key_map: HashMap<TextureKey, usize>,
 
-    pub sound_map: HashMap<SoundKey, Sound>
+    pub sound_map: HashMap<SoundKey, Sound>,
+    asset_folder_root: String,
+    user_data_folder_root: String,
 }
 impl AssetStore {
     pub fn new(ctx: &mut Context) -> Self {
@@ -33,6 +44,9 @@ impl AssetStore {
 
         let mut textures = Vec::with_capacity(INITIAL_TEXTURE_STORAGE_CAPACITY);
         textures.push(default_texture);
+
+        let asset_folder_root = String::from(DEFAULT_ASSET_FOLDER);
+        let user_data_folder_root = String::from(DEFAULT_USER_DATA_FOLDER);
 
         AssetStore {
             bytes: HashMap::new(),
@@ -45,11 +59,55 @@ impl AssetStore {
             texture_key_map,
 
             sound_map: HashMap::new(),
+            asset_folder_root,
+            user_data_folder_root,
         }
     }
 
-    pub fn insert_bytes(&mut self, name: String, bytes: Vec<u8>) {
-        self.bytes.insert(name, bytes);
+    pub fn set_asset_folder_root(&mut self, root: String) {
+        self.asset_folder_root = root;
+    }
+
+    pub fn set_user_data_folder_root(&mut self, root: String) {
+        self.user_data_folder_root = root;
+    }
+
+    pub fn insert_asset_bytes(&mut self, relative_path: String, bytes: Vec<u8>) -> Result<(), EmeraldError> {
+        let path = self.get_full_asset_path(&relative_path);
+        self.bytes.insert(path, bytes);
+
+        Ok(())
+    }
+    pub fn get_asset_bytes(&mut self, relative_path: &String) -> Option<Vec<u8>> {
+        let full_path = self.get_full_asset_path(relative_path);
+        self.get_bytes(full_path)
+    }
+    pub fn read_asset_file(&mut self, relative_path: &String) -> Result<Vec<u8>, EmeraldError> {
+        let full_path = self.get_full_asset_path(relative_path);
+        read_file(&full_path)
+    }
+
+    pub fn insert_user_bytes(&mut self, relative_path: String, bytes: Vec<u8>) -> Result<(), EmeraldError> {
+        let path = self.get_full_user_data_path(&relative_path);
+        self.bytes.insert(path, bytes);
+
+        Ok(())
+    }
+    pub fn get_user_bytes(&mut self, relative_path: &String) -> Option<Vec<u8>> {
+        let full_path = self.get_full_user_data_path(relative_path);
+        self.get_bytes(full_path)
+    }
+    pub fn read_user_file(&mut self, relative_path: &String) -> Result<Vec<u8>, EmeraldError> {
+        let full_path = self.get_full_user_data_path(relative_path);
+        read_file(&full_path)
+    }
+
+    fn get_bytes(&mut self, path: String) -> Option<Vec<u8>> {
+        if let Some(bytes) = self.bytes.get(&path) {
+            return Some(bytes.clone());
+        }
+
+        None
     }
 
     pub fn insert_fontdue_font(&mut self, key: FontKey, font: fontdue::Font) {
@@ -75,12 +133,19 @@ impl AssetStore {
         self.texture_key_map.insert(key, self.textures.len() - 1);
     }
 
-    pub fn get_bytes(&self, name: &String) -> Option<Vec<u8>> {
-        if let Some(bytes) = self.bytes.get(name) {
-            return Some(bytes.clone());
-        }
+    pub fn get_full_asset_path(&self, path: &String) -> String {
+        let mut full_path = self.asset_folder_root.clone();
+        full_path.push_str(path);
 
-        None
+        full_path
+    }
+
+
+    pub fn get_full_user_data_path(&self, path: &String) -> String {
+        let mut full_path = self.user_data_folder_root.clone();
+        full_path.push_str(path);
+
+        full_path
     }
 
     pub fn get_fontdue_font(&self, key: &FontKey) -> Option<&fontdue::Font> {
@@ -179,4 +244,58 @@ impl AssetStore {
             }
         }
     }
+
+    #[inline]
+    pub fn contains_sound(&self, key: &SoundKey) -> bool {
+        self.sound_map.contains_key(key)
+    }
+
+    #[inline]
+    pub fn insert_sound(&mut self, key: SoundKey, sound: Sound) {
+        self.sound_map.insert(key, sound);
+    }
+}
+
+
+#[cfg(target_arch = "wasm32")]
+fn read_file(path: &str) -> Result<Vec<u8>, EmeraldError> {
+    Err(EmeraldError::new(format!(
+        "Unable to get bytes for {}",
+        path
+    )))
+}
+
+#[cfg(target_os = "android")]
+fn read_file(path: &str) -> Result<Vec<u8>, EmeraldError> {
+    // Based on https://github.com/not-fl3/miniquad/blob/4be5328760ff356494caf59cc853bcb395bce5d2/src/fs.rs#L38-L53
+
+    let filename = std::ffi::CString::new(path).unwrap();
+
+    let mut data: sapp_android::android_asset = unsafe { std::mem::zeroed() };
+
+    unsafe { sapp_android::sapp_load_asset(filename.as_ptr(), &mut data as _) };
+
+    if data.content.is_null() == false {
+        let slice =
+            unsafe { std::slice::from_raw_parts(data.content, data.content_length as _) };
+        let response = slice.iter().map(|c| *c as _).collect::<Vec<_>>();
+        Ok(response)
+    } else {
+        Err(EmeraldError::new(format!("Unable to load asset `{}`", path)))
+    }
+}
+
+#[cfg(not(any(target_arch = "wasm32", target_os = "android")))]
+fn read_file(path: &str) -> Result<Vec<u8>, EmeraldError> {
+    use std::fs::File;
+    use std::io::Read;
+
+    let current_dir = std::env::current_dir()?;
+    let path = current_dir.join(path);
+    let path = path.into_os_string().into_string()?;
+
+    let mut contents = vec![];
+    let mut file = File::open(path)?;
+    file.read_to_end(&mut contents)?;
+    Ok(contents)
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -54,6 +54,14 @@ impl<'a> Emerald<'a> {
         }
     }
 
+    pub fn set_asset_folder_root(&mut self, root: String) {
+        self.asset_store.set_asset_folder_root(root);
+    }
+
+    pub fn set_user_data_folder_root(&mut self, root: String) {
+        self.asset_store.set_user_data_folder_root(root);
+    }
+
     // ************* General API ***************
     #[inline]
     pub fn delta(&self) -> f32 {


### PR DESCRIPTION
Files are loaded from the user data directory, and the asset directory. The user can change the root path for each directory.

This change allows people to use simple paths for their assets. This also improves portability because the engine can automatically define where the USER_DATA_DIR and ASSETS_DIR should default to, per platform. Example, windows would store user data in AppData for the game, macOS would store it in the Library for the game. Assets on android will be easier to access also.

Before: `loader().sprite("./assets/my_thing.png")`
After: `loader().sprite("my_thing.png")`