### PR TITLE
Kira mixers should use a singleton audio manager, this is much cleaner

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -12,6 +12,7 @@ impl EmeraldError {
     }
 }
 
+
 // Kira audio backend error translations
 #[cfg(feature = "audio")]
 impl std::convert::From<kira::CommandError> for EmeraldError {


### PR DESCRIPTION
Using multiple AudioManagers can possibly cause issues, it additionally makes managing settings for all audio easier. Additionally, multiple audio managers creates multiple audio streams which we don't want.