### PR TITLE
Fix button behavior to fit modern standards (i think)

### DIFF
--- a/src/input/components/ui_button.rs
+++ b/src/input/components/ui_button.rs
@@ -50,4 +50,9 @@ impl UIButton {
         self.was_pressed = self.is_pressed;
         self.is_pressed = false;
     }
+
+    pub fn reset(&mut self) {
+        self.is_pressed = false;
+        self.was_pressed = false;
+    }
 }

--- a/src/input/systems/ui_button.rs
+++ b/src/input/systems/ui_button.rs
@@ -1,7 +1,5 @@
 use crate::{Emerald, EmeraldWorld, Position, UIButton, screen_position_to_world_position};
 
-
-
 /// Updates the status of UI Buttons.
 /// Presses the button if the user has pressed it, etc...
 pub fn ui_button_system(emd: &mut Emerald<'_>, world: &mut EmeraldWorld) {
@@ -11,13 +9,14 @@ pub fn ui_button_system(emd: &mut Emerald<'_>, world: &mut EmeraldWorld) {
 
     for (_, (ui_button, position)) in world.query::<(&mut UIButton, &Position)>().iter() {
         if is_mouse_inside_button(emd, &ui_button, &position, &mouse_position) {
-            if mouse.left.is_pressed {
+            if mouse.left.is_just_pressed() || (ui_button.is_pressed() && mouse.left.is_pressed) {
                 ui_button.press();
+            } else {
+                ui_button.release();
             }
-        }
-
-        if !mouse.left.is_pressed {
-            ui_button.release();
+        } else {
+            // Wipe button state if mouse is not in button
+            ui_button.reset();
         }
     }
 }


### PR DESCRIPTION
Makes it so that when the user is holding the left mouse button down when slider onto the button, it does not press it. It also safely releases the button if a mouse slides out of bounds, without pressing it.