### PR TITLE
Use bombfuse fork of miniquad for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,13 @@ rapier2d = { version = "0.11.0", optional = true  }
 gamepad = { version = "0.1.4", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-miniquad = { version = "0.3.0-alpha.43", features = [ "log-impl" ] }
+miniquad = { git = "https://github.com/Bombfuse/miniquad", branch = "master", features=["log-impl"] }
+#miniquad = { version = "0.3.0-alpha.43", features = [ "log-impl" ] }
 kira = { version= "0.5.3", optional = true, default-features = false, features = ["ogg", "flac", "wav"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
-miniquad = "0.3.0-alpha.43"
+miniquad = { git = "https://github.com/Bombfuse/miniquad", branch = "master" }
+#miniquad = "0.3.0-alpha.43"
 kira = { version= "0.5.3", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,16 +66,14 @@ pub fn start<G>(game: G, settings: GameSettings)
 where
     G: Game + 'static,
 {
-    let config = conf::Conf {
-        window_title: settings.title.clone(),
-        window_width: settings.render_settings.resolution.0 as i32,
-        window_height: settings.render_settings.resolution.1 as i32,
-        fullscreen: settings.render_settings.fullscreen,
-        high_dpi: settings.render_settings.high_dpi,
-        window_resizable: settings.render_settings.resizable_window,
-        icon: settings.render_settings.icon.clone(),
-        ..Default::default()
-    };
+    let mut config = conf::Conf::default();
+    config.window_title = settings.title.clone();
+    config.window_width = settings.render_settings.resolution.0 as i32;
+    config.window_height = settings.render_settings.resolution.1 as i32;
+    config.fullscreen = settings.render_settings.fullscreen;
+    config.high_dpi = settings.render_settings.high_dpi;
+    config.window_resizable = settings.render_settings.resizable_window;
+    config.icon = settings.render_settings.icon.clone();
 
     miniquad::start(config, move |mut ctx| {
         UserData::owning(GameEngine::new(game, settings, &mut ctx), ctx)


### PR DESCRIPTION
Temporarily use my fork of miniquad that contains a hotfix for the icon support until the hotfix is applied to the main repo and crates is updated.