### PR TITLE
World merging and rendering fixes

### DIFF
--- a/examples/world_merging.rs
+++ b/examples/world_merging.rs
@@ -1,0 +1,64 @@
+use std::time::Duration;
+
+use emerald::*;
+
+pub fn main() {
+    emerald::start(
+        WorldMergingExample {
+            world: World::new(),
+        },
+        GameSettings::default(),
+    )
+}
+
+pub struct WorldMergingExample {
+    world: World,
+}
+impl Game for WorldMergingExample {
+    fn initialize(&mut self, mut emd: Emerald) {
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
+        let sprite = emd.loader().sprite("bunny.png").unwrap();
+        self.world.spawn((sprite, Transform::default()));
+        self.world.physics().set_gravity(Vector2::new(0.0, -19.8));
+    }
+
+    fn update(&mut self, mut emd: Emerald) {
+        let mut input = emd.input();
+
+        if input.is_key_just_pressed(KeyCode::A) {
+            let amount = 100;
+            let world = build_other_world(&mut emd, Transform::from_translation((100.0, 100.0)), amount).unwrap();
+            let now = emd.now();
+            self.world.merge(world).unwrap();
+            let after = emd.now();
+            println!("merged {} bunnies in {:?}us", amount, Duration::from_secs_f64(after - now).as_micros());
+        }
+
+        self.world.physics().step(emd.delta());
+    }
+
+    fn draw(&mut self, mut emd: Emerald) {
+        emd.graphics().begin().unwrap();
+        emd.graphics().draw_world(&mut self.world).unwrap();
+        emd.graphics().render().unwrap();
+    }
+}
+
+fn build_other_world(emd: &mut Emerald, offset: Transform, amount: i32) -> Result<World, EmeraldError> {
+    let mut world = World::new();
+    let sprite = emd.loader().sprite("bunny.png")?;
+    let amount = (amount as f32).sqrt() as usize;
+
+    for x in 0..amount {
+        for y in 0..amount {
+            let (_entity, rbh) = world.spawn_with_body((
+                Transform::from_translation((x as f32 * 30.0 - 300.0, y as f32 * 30.0 - 300.0)) + offset,
+                sprite.clone()
+            ), RigidBodyBuilder::new_dynamic().can_sleep(false).linvel(Vector2::new(10.0, 10.0))).unwrap();
+    
+            world.physics().build_collider(rbh, ColliderBuilder::cuboid(1.0, 1.0));
+        }
+    }
+
+    Ok(world)
+}

--- a/src/rendering/handler.rs
+++ b/src/rendering/handler.rs
@@ -23,7 +23,7 @@ impl<'a> GraphicsHandler<'a> {
     }
 
     pub fn draw_world(&mut self, world: &mut World) -> Result<(), EmeraldError> {
-        self.rendering_engine.draw_world(world)
+        self.rendering_engine.draw_world(world, &mut self.asset_store)
     }
 
     #[cfg(feature = "physics")]


### PR DESCRIPTION
Eventually we'll need to build on top of hecs::Entity and offer an emerald::Entity that guarantees a Universally Unique ID. Once that happens we can remove the "Old Entity Id -> New Entity Id" map