### PR TITLE
Autotilemap

### DIFF
--- a/examples/autotilemap.rs
+++ b/examples/autotilemap.rs
@@ -1,0 +1,192 @@
+use emerald::{
+    autotilemap::{AutoTile, AutoTileRuleset, AutoTileRulesetValue, AutoTilemap},
+    Camera, Emerald, Game, GameSettings, Transform, Vector2, World,
+};
+
+pub fn main() {
+    emerald::start(
+        Box::new(AutotilemapExample {
+            world: World::new(),
+        }),
+        GameSettings::default(),
+    )
+}
+
+pub struct AutotilemapExample {
+    world: World,
+}
+impl Game for AutotilemapExample {
+    fn initialize(&mut self, mut emd: Emerald) {
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
+
+        let rulesets = vec![
+            // An autotile ruleset that only places the first tile when it is not immediately surrounded by other tiles.
+            AutoTileRuleset {
+                tile_id: 0,
+                grid: [
+                    // Column 1
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    // Column 2
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::None,
+                        AutoTileRulesetValue::None,
+                        AutoTileRulesetValue::None,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    // Column 3
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::None,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::None,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    // Column 4
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::None,
+                        AutoTileRulesetValue::None,
+                        AutoTileRulesetValue::None,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    // Column 5
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                    ],
+                ],
+            },
+            // An autotile ruleset that only places the second tile when it is surrounded by tiles immediately
+            AutoTileRuleset {
+                tile_id: 1,
+                grid: [
+                    // Column 1
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    // Column 2
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    // Column 3
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    // Column 4
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    // Column 5
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                    ],
+                ],
+            },
+            // An autotile ruleset that places the third tile in any other scenario
+            AutoTileRuleset {
+                tile_id: 2,
+                grid: [
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Tile,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                    ],
+                    [
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                        AutoTileRulesetValue::Any,
+                    ],
+                ],
+            },
+        ];
+
+        let tileset_key = emd.loader().texture("tileset.png").unwrap();
+        let mut autotilemap = AutoTilemap::new(tileset_key, Vector2::new(16, 16), 20, 20, rulesets);
+
+        autotilemap.set_tile(0, 0).unwrap(); // tile_id 2
+        autotilemap.set_tile(10, 4).unwrap(); // tile_id 2
+        autotilemap.set_tile(11, 4).unwrap(); // tile_id 2
+        autotilemap.set_tile(19, 4).unwrap(); // tile_id 0
+        autotilemap.set_tile(10, 10).unwrap(); // tile_id 0
+
+        autotilemap.set_tile(15, 15).unwrap();
+        autotilemap.set_tile(16, 15).unwrap();
+        autotilemap.set_tile(17, 15).unwrap();
+        autotilemap.set_tile(15, 16).unwrap();
+        autotilemap.set_tile(16, 16).unwrap(); // we should see tile_id 1 here
+        autotilemap.set_tile(17, 16).unwrap();
+        autotilemap.set_tile(15, 17).unwrap();
+        autotilemap.set_tile(16, 17).unwrap();
+        autotilemap.set_tile(17, 17).unwrap();
+
+        autotilemap.bake().unwrap();
+
+        let e = self
+            .world
+            .spawn((autotilemap, Transform::default(), Camera::default()));
+        self.world.make_active_camera(e).unwrap();
+    }
+
+    fn update(&mut self, _emd: Emerald) {}
+
+    fn draw(&mut self, mut emd: Emerald) {
+        emd.graphics().begin().unwrap();
+        emd.graphics().draw_world(&mut self.world).unwrap();
+        emd.graphics().render().unwrap();
+    }
+}

--- a/src/core/components.rs
+++ b/src/core/components.rs
@@ -1,2 +1,3 @@
+pub mod autotilemap;
 pub mod tilemap;
 pub mod transform;

--- a/src/core/components/autotilemap.rs
+++ b/src/core/components/autotilemap.rs
@@ -1,0 +1,128 @@
+use std::{collections::HashMap, ops::Index};
+
+use nalgebra::Vector2;
+
+use crate::{
+    tilemap::{TileId, Tilemap},
+    EmeraldError, TextureKey,
+};
+
+pub enum AutoTileValue {
+    None,
+    Tile,
+    Any,
+}
+
+pub struct AutoTileRuleset {
+    pub tile_id: TileId,
+
+    /// A grid determining the ruleset that displays this tile.
+    /// Most grids will only need to cover a 3x3 area around the center tile,
+    /// however we offer a 5x5 to cover larger rulesets.
+    /// Ex 1.
+    /// [
+    ///     [None, None, None, None, None]
+    ///     [None, None, None, None, None]
+    ///     [None, None, THIS_TILE, None, None]
+    ///     [None, None, None, None, None]
+    ///     [None, None, None, None, None]
+    /// ]
+    /// The above grid displays the tile when it is completely alone, and not surrounded by any tiles.
+    /// The value in the center of the ruleset grid is ignored, as this space is reserved for the AutoTile.
+    ///
+    /// Ex 2.
+    /// [
+    ///     [None, None, None, None, None]
+    ///     [None, None, Any, None, None]
+    ///     [None, None, THIS_TILE, None, None]
+    ///     [None, None, Tile, None, None]
+    ///     [None, None, None, None, None]
+    /// ]
+    /// This example will display the given tile, when there is a tile below the center and
+    /// does not care about the tile above center.
+    pub grid: [[AutoTileValue; 5]; 5],
+}
+
+pub struct Autotilemap {
+    tilemap: Tilemap,
+    pub z_index: f32,
+    pub visible: bool,
+    rulesets: Vec<AutoTileRuleset>,
+    tiles: Vec<AutoTileValue>,
+}
+impl Autotilemap {
+    pub fn new(
+        tilesheet: TextureKey,
+        // Size of a tile in the grid, in pixels
+        tile_size: Vector2<usize>,
+        map_width: usize,
+        map_height: usize,
+        rulesets: Vec<AutoTileRuleset>,
+    ) -> Self {
+        let tilemap = Tilemap::new(tilesheet, tile_size, map_width, map_height);
+
+        let tile_count = map_width * map_height;
+        let mut tiles = Vec::with_capacity(tile_count);
+        for _ in 0..tile_count {
+            tiles.push(AutoTileValue::None);
+        }
+
+        Autotilemap {
+            tilemap,
+            z_index: 0.0,
+            visible: true,
+            rulesets,
+            tiles,
+        }
+    }
+
+    /// Bakes the inner tileset in accordance to the Autotilemap
+    /// feature(physics): Additionally bakes the colliders
+    pub fn bake(&mut self) {}
+
+    pub fn width(&self) -> usize {
+        self.tilemap.width
+    }
+
+    pub fn height(&self) -> usize {
+        self.tilemap.height
+    }
+
+    pub fn add_ruleset(&mut self, ruleset: AutoTileRuleset) {
+        self.rulesets.push(ruleset);
+    }
+
+    pub fn remove_ruleset(&mut self, tile_id: TileId) -> Option<AutoTileRuleset> {
+        if let Some(index) = self
+            .rulesets
+            .iter()
+            .position(|ruleset| ruleset.tile_id == tile_id)
+        {
+            return Some(self.rulesets.remove(index));
+        }
+
+        None
+    }
+
+    fn get_index(&self, x: usize, y: usize) -> Result<usize, EmeraldError> {
+        if x >= self.width() {
+            return Err(EmeraldError::new(format!(
+                "{} is not within the width ({}) of the Autotilemap.",
+                x,
+                self.width()
+            )));
+        }
+
+        if y >= self.height() {
+            return Err(EmeraldError::new(format!(
+                "{} is not within the height ({}) of the Autotilemap.",
+                y,
+                self.height()
+            )));
+        }
+
+        Ok(y * self.width() + x)
+    }
+}
+#[test]
+fn test_autotiles() {}

--- a/src/core/components/autotilemap.rs
+++ b/src/core/components/autotilemap.rs
@@ -3,54 +3,144 @@ use std::{collections::HashMap, ops::Index};
 use nalgebra::Vector2;
 
 use crate::{
-    tilemap::{TileId, Tilemap},
-    EmeraldError, TextureKey,
+    tilemap::{get_tilemap_index, TileId, Tilemap},
+    Emerald, EmeraldError, TextureKey,
 };
 
-pub enum AutoTileValue {
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
+pub enum AutoTileRulesetValue {
     None,
     Tile,
     Any,
 }
+
+const AUTOTILE_RULESET_GRID_SIZE: usize = 5;
 
 pub struct AutoTileRuleset {
     pub tile_id: TileId,
 
     /// A grid determining the ruleset that displays this tile.
     /// Most grids will only need to cover a 3x3 area around the center tile,
-    /// however we offer a 5x5 to cover larger rulesets.
+    /// however we offer a 5x5 to cover larger rulesets. If you don't care to use all
+    /// all of the 5x5 grid, place the outer rings with AutoTile::Any.
+    ///
+    /// These grids are rotated 90* clockwise visually.
     /// Ex 1.
     /// [
-    ///     [None, None, None, None, None]
-    ///     [None, None, None, None, None]
-    ///     [None, None, THIS_TILE, None, None]
-    ///     [None, None, None, None, None]
-    ///     [None, None, None, None, None]
+    ///     [Any, Any, Any, Any, Any]
+    ///     [Any, None, None, None, Any]
+    ///     [Any, None, Tile, None, Any]
+    ///     [Any, None, None, None, Any]
+    ///     [Any, Any, Any, Any, Any]
     /// ]
     /// The above grid displays the tile when it is completely alone, and not surrounded by any tiles.
     /// The value in the center of the ruleset grid is ignored, as this space is reserved for the AutoTile.
     ///
     /// Ex 2.
     /// [
-    ///     [None, None, None, None, None]
-    ///     [None, None, Any, None, None]
-    ///     [None, None, THIS_TILE, None, None]
-    ///     [None, None, Tile, None, None]
-    ///     [None, None, None, None, None]
+    ///     [Any, Any, Any, Any, Any]
+    ///     [Any, None, Any, None, Any]
+    ///     [Any, None, Tile, None, Any]
+    ///     [Any, None, Tile, None, Any]
+    ///     [Any, Any, Any, Any, Any]
     /// ]
-    /// This example will display the given tile, when there is a tile below the center and
-    /// does not care about the tile above center.
-    pub grid: [[AutoTileValue; 5]; 5],
+    /// This example will display the given tile, when there is a tile right of the center and
+    /// does not care about the tile left of center.
+    pub grid: [[AutoTileRulesetValue; AUTOTILE_RULESET_GRID_SIZE]; AUTOTILE_RULESET_GRID_SIZE],
+}
+impl AutoTileRuleset {
+    /// Tests a 5x5 area centering on the given x, y values and determines if it's a match.
+    pub(crate) fn matches(
+        &self,
+        autotiles: &Vec<AutoTile>,
+        autotilemap_width: usize,
+        autotilemap_height: usize,
+        x: usize,
+        y: usize,
+    ) -> bool {
+        match get_tilemap_index(x, y, autotilemap_width, autotilemap_height) {
+            Err(_) => {
+                return false;
+            }
+            Ok(index) => {
+                if autotiles[index] != AutoTile::Tile {
+                    return false;
+                }
+            }
+        }
+
+        for ruleset_x in 0..AUTOTILE_RULESET_GRID_SIZE {
+            for ruleset_y in 0..AUTOTILE_RULESET_GRID_SIZE {
+                // If center tile or any, skip
+                if (ruleset_x == (AUTOTILE_RULESET_GRID_SIZE / 2)
+                    && ruleset_y == (AUTOTILE_RULESET_GRID_SIZE / 2))
+                    || self.grid[ruleset_x][ruleset_y] == AutoTileRulesetValue::Any
+                {
+                    continue;
+                }
+
+                let autotile_ruleset_value = self.get_autotile_ruleset_value(
+                    autotiles,
+                    autotilemap_width,
+                    autotilemap_height,
+                    x as isize - (AUTOTILE_RULESET_GRID_SIZE / 2) as isize + ruleset_x as isize,
+                    y as isize - (AUTOTILE_RULESET_GRID_SIZE / 2) as isize + ruleset_y as isize,
+                );
+
+                if self.grid[ruleset_x][ruleset_y] != autotile_ruleset_value {
+                    println!(
+                        "{:?} did not match expected {:?}",
+                        autotile_ruleset_value, self.grid[ruleset_x][ruleset_y]
+                    );
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn get_autotile_ruleset_value(
+        &self,
+        autotiles: &Vec<AutoTile>,
+        autotilemap_width: usize,
+        autotilemap_height: usize,
+        x: isize,
+        y: isize,
+    ) -> AutoTileRulesetValue {
+        // Treat tiles outside the boundaries of the map as Any.
+        if x < 0 || y < 0 {
+            return AutoTileRulesetValue::Any;
+        }
+
+        match get_tilemap_index(
+            x as usize,
+            y as usize,
+            autotilemap_width,
+            autotilemap_height,
+        ) {
+            Ok(index) => match autotiles[index] {
+                AutoTile::None => AutoTileRulesetValue::None,
+                AutoTile::Tile => AutoTileRulesetValue::Tile,
+            },
+            // Out of bounds, so we assume any
+            Err(_) => AutoTileRulesetValue::Any,
+        }
+    }
 }
 
-pub struct Autotilemap {
-    tilemap: Tilemap,
-    pub z_index: f32,
-    pub visible: bool,
-    rulesets: Vec<AutoTileRuleset>,
-    tiles: Vec<AutoTileValue>,
+#[derive(Clone, Copy, Debug, PartialEq, Hash)]
+pub enum AutoTile {
+    None = 0,
+    Tile = 1,
 }
-impl Autotilemap {
+
+pub struct AutoTilemap {
+    pub(crate) tilemap: Tilemap,
+    rulesets: Vec<AutoTileRuleset>,
+    autotiles: Vec<AutoTile>,
+}
+impl AutoTilemap {
     pub fn new(
         tilesheet: TextureKey,
         // Size of a tile in the grid, in pixels
@@ -62,23 +152,29 @@ impl Autotilemap {
         let tilemap = Tilemap::new(tilesheet, tile_size, map_width, map_height);
 
         let tile_count = map_width * map_height;
-        let mut tiles = Vec::with_capacity(tile_count);
+        let mut autotiles = Vec::with_capacity(tile_count);
         for _ in 0..tile_count {
-            tiles.push(AutoTileValue::None);
+            autotiles.push(AutoTile::None);
         }
 
-        Autotilemap {
+        Self {
             tilemap,
-            z_index: 0.0,
-            visible: true,
             rulesets,
-            tiles,
+            autotiles,
         }
     }
 
     /// Bakes the inner tileset in accordance to the Autotilemap
     /// feature(physics): Additionally bakes the colliders
-    pub fn bake(&mut self) {}
+    pub fn bake(&mut self) -> Result<(), EmeraldError> {
+        for x in 0..self.width() {
+            for y in 0..self.height() {
+                self.tilemap.set_tile(x, y, self.compute_tile_id(x, y)?)?;
+            }
+        }
+
+        Ok(())
+    }
 
     pub fn width(&self) -> usize {
         self.tilemap.width
@@ -88,8 +184,51 @@ impl Autotilemap {
         self.tilemap.height
     }
 
+    pub fn tilesheet(&self) -> TextureKey {
+        self.tilemap.tilesheet.clone()
+    }
+
+    pub fn tile_size(&self) -> Vector2<usize> {
+        self.tilemap.tile_size.clone()
+    }
+
     pub fn add_ruleset(&mut self, ruleset: AutoTileRuleset) {
         self.rulesets.push(ruleset);
+    }
+
+    pub fn get_autotile(&mut self, x: usize, y: usize) -> Result<AutoTile, EmeraldError> {
+        let index = get_tilemap_index(x, y, self.width(), self.height())?;
+        Ok(self.autotiles[index])
+    }
+
+    pub fn set_tile(&mut self, x: usize, y: usize) -> Result<(), EmeraldError> {
+        self.set_autotile(x, y, AutoTile::Tile)
+    }
+
+    pub fn set_none(&mut self, x: usize, y: usize) -> Result<(), EmeraldError> {
+        self.set_autotile(x, y, AutoTile::None)
+    }
+
+    pub fn set_autotile(
+        &mut self,
+        x: usize,
+        y: usize,
+        new_tile_id: AutoTile,
+    ) -> Result<(), EmeraldError> {
+        let index = get_tilemap_index(x, y, self.width(), self.height())?;
+        self.autotiles[index] = new_tile_id;
+
+        Ok(())
+    }
+
+    pub fn tiles(&self) -> &Vec<Option<TileId>> {
+        &self.tilemap.tiles
+    }
+
+    pub fn get_ruleset(&self, tile_id: TileId) -> Option<&AutoTileRuleset> {
+        self.rulesets
+            .iter()
+            .find(|ruleset| ruleset.tile_id == tile_id)
     }
 
     pub fn remove_ruleset(&mut self, tile_id: TileId) -> Option<AutoTileRuleset> {
@@ -104,24 +243,21 @@ impl Autotilemap {
         None
     }
 
-    fn get_index(&self, x: usize, y: usize) -> Result<usize, EmeraldError> {
-        if x >= self.width() {
-            return Err(EmeraldError::new(format!(
-                "{} is not within the width ({}) of the Autotilemap.",
-                x,
-                self.width()
-            )));
+    /// Computes the tileid for the given autotile position.
+    pub fn compute_tile_id(&self, x: usize, y: usize) -> Result<Option<TileId>, EmeraldError> {
+        if let Some(ruleset) = self
+            .rulesets
+            .iter()
+            .find(|ruleset| ruleset.matches(&self.autotiles, self.width(), self.height(), x, y))
+        {
+            println!("matching id {:?}", ruleset.tile_id);
+            return Ok(Some(ruleset.tile_id));
         }
 
-        if y >= self.height() {
-            return Err(EmeraldError::new(format!(
-                "{} is not within the height ({}) of the Autotilemap.",
-                y,
-                self.height()
-            )));
-        }
-
-        Ok(y * self.width() + x)
+        Ok(None)
+    }
+    pub fn get_tile_id(&self, x: usize, y: usize) -> Result<Option<TileId>, EmeraldError> {
+        self.tilemap.get_tile(x, y)
     }
 }
 #[test]

--- a/src/core/components/autotilemap.rs
+++ b/src/core/components/autotilemap.rs
@@ -88,10 +88,6 @@ impl AutoTileRuleset {
                 );
 
                 if self.grid[ruleset_x][ruleset_y] != autotile_ruleset_value {
-                    println!(
-                        "{:?} did not match expected {:?}",
-                        autotile_ruleset_value, self.grid[ruleset_x][ruleset_y]
-                    );
                     return false;
                 }
             }
@@ -165,7 +161,7 @@ impl AutoTilemap {
     }
 
     /// Bakes the inner tileset in accordance to the Autotilemap
-    /// feature(physics): Additionally bakes the colliders
+    /// TODO: feature(physics): Additionally bakes the colliders
     pub fn bake(&mut self) -> Result<(), EmeraldError> {
         for x in 0..self.width() {
             for y in 0..self.height() {
@@ -250,7 +246,6 @@ impl AutoTilemap {
             .iter()
             .find(|ruleset| ruleset.matches(&self.autotiles, self.width(), self.height(), x, y))
         {
-            println!("matching id {:?}", ruleset.tile_id);
             return Ok(Some(ruleset.tile_id));
         }
 

--- a/src/core/components/tilemap.rs
+++ b/src/core/components/tilemap.rs
@@ -1,18 +1,21 @@
 use crate::*;
 
+pub type TileId = usize;
+
 #[derive(Clone)]
 pub struct Tilemap {
     pub(crate) width: usize,
     pub(crate) height: usize,
     pub(crate) tilesheet: TextureKey,
     pub(crate) tile_size: Vector2<usize>,
-    pub(crate) tiles: Vec<Option<usize>>,
+    pub(crate) tiles: Vec<Option<TileId>>,
     pub z_index: f32,
     pub visible: bool,
 }
 impl Tilemap {
     pub fn new(
         tilesheet: TextureKey,
+        // Size of a tile in the grid, in pixels
         tile_size: Vector2<usize>,
         width: usize,
         height: usize,
@@ -34,7 +37,7 @@ impl Tilemap {
         }
     }
 
-    pub fn get_tile(&mut self, x: usize, y: usize) -> Result<Option<usize>, EmeraldError> {
+    pub fn get_tile(&mut self, x: usize, y: usize) -> Result<Option<TileId>, EmeraldError> {
         let tile_index = self.get_index(x, y)?;
 
         if let Some(tile) = self.tiles.get_mut(tile_index) {
@@ -56,7 +59,7 @@ impl Tilemap {
         &mut self,
         x: usize,
         y: usize,
-        new_tile: Option<usize>,
+        new_tile: Option<TileId>,
     ) -> Result<(), EmeraldError> {
         let tile_index = self.get_index(x, y)?;
 

--- a/src/core/components/tilemap.rs
+++ b/src/core/components/tilemap.rs
@@ -37,10 +37,10 @@ impl Tilemap {
         }
     }
 
-    pub fn get_tile(&mut self, x: usize, y: usize) -> Result<Option<TileId>, EmeraldError> {
-        let tile_index = self.get_index(x, y)?;
+    pub fn get_tile(&self, x: usize, y: usize) -> Result<Option<TileId>, EmeraldError> {
+        let tile_index = get_tilemap_index(x, y, self.width, self.height)?;
 
-        if let Some(tile) = self.tiles.get_mut(tile_index) {
+        if let Some(tile) = self.tiles.get(tile_index) {
             let tile = tile.map(|id| id);
 
             return Ok(tile);
@@ -61,7 +61,7 @@ impl Tilemap {
         y: usize,
         new_tile: Option<TileId>,
     ) -> Result<(), EmeraldError> {
-        let tile_index = self.get_index(x, y)?;
+        let tile_index = get_tilemap_index(x, y, self.width, self.height)?;
 
         if let Some(tile_id) = self.tiles.get_mut(tile_index) {
             *tile_id = new_tile;
@@ -93,22 +93,27 @@ impl Tilemap {
     pub fn set_tilesheet(&mut self, tilesheet: TextureKey) {
         self.tilesheet = tilesheet
     }
+}
 
-    fn get_index(&self, x: usize, y: usize) -> Result<usize, EmeraldError> {
-        if x >= self.width {
-            return Err(EmeraldError::new(format!(
-                "Given x: {} is outside the width of {}",
-                x, self.width
-            )));
-        }
-
-        if y >= self.height {
-            return Err(EmeraldError::new(format!(
-                "Given y: {} is outside the height of {}",
-                y, self.height
-            )));
-        }
-
-        Ok((y * self.width) + x)
+pub(crate) fn get_tilemap_index(
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+) -> Result<usize, EmeraldError> {
+    if x >= width {
+        return Err(EmeraldError::new(format!(
+            "Given x: {} is outside the width of {}",
+            x, width
+        )));
     }
+
+    if y >= height {
+        return Err(EmeraldError::new(format!(
+            "Given y: {} is outside the height of {}",
+            y, height
+        )));
+    }
+
+    Ok((y * width) + x)
 }

--- a/src/rendering/engine.rs
+++ b/src/rendering/engine.rs
@@ -1,3 +1,4 @@
+use crate::autotilemap::AutoTilemap;
 use crate::rendering::*;
 use crate::tilemap::Tilemap;
 use crate::transform::Transform;
@@ -171,6 +172,7 @@ impl RenderingEngine {
         #[cfg(feature = "aseprite")]
         cmd_adder.add_draw_commands::<Aseprite>(&mut draw_queue, world, asset_store);
 
+        cmd_adder.add_draw_commands::<AutoTilemap>(&mut draw_queue, world, asset_store);
         cmd_adder.add_draw_commands::<Tilemap>(&mut draw_queue, world, asset_store);
         cmd_adder.add_draw_commands::<Sprite>(&mut draw_queue, world, asset_store);
         cmd_adder.add_draw_commands::<UIButton>(&mut draw_queue, world, asset_store);
@@ -980,6 +982,23 @@ impl ToDrawable for Tilemap {
 
     fn z_index(&self) -> f32 {
         self.z_index
+    }
+}
+impl ToDrawable for AutoTilemap {
+    fn get_visible_bounds(
+        &self,
+        transform: &Transform,
+        asset_store: &mut AssetStore,
+    ) -> Option<Rectangle> {
+        self.tilemap.get_visible_bounds(transform, asset_store)
+    }
+
+    fn to_drawable(&self) -> Drawable {
+        self.tilemap.to_drawable()
+    }
+
+    fn z_index(&self) -> f32 {
+        self.tilemap.z_index
     }
 }
 


### PR DESCRIPTION
Initial feature set for AutoTilemaps. Support rulesets that determine the tile id, in the future these tiles will be able to be baked into physics colliders.