### PR TITLE
added pixel_snap render setting

### DIFF
--- a/src/rendering/engine.rs
+++ b/src/rendering/engine.rs
@@ -848,7 +848,9 @@ fn draw_texture(
     resolution: (usize, usize),
 ) {
     // Bump position up by half a unit then floor, for pixel snap
-    position = Vec2::new((position.x + 0.5).floor(), (position.y + 0.5).floor());
+    if _settings.pixel_snap {
+        position = Vec2::new((position.x + 0.5).floor(), (position.y + 0.5).floor());
+    }
 
     let projection = Mat4::orthographic_rh_gl(
         0.0,

--- a/src/rendering/engine.rs
+++ b/src/rendering/engine.rs
@@ -834,7 +834,7 @@ impl RenderingEngine {
 
 #[inline]
 fn draw_texture(
-    _settings: &RenderSettings,
+    settings: &RenderSettings,
     mut ctx: &mut Context,
     asset_store: &mut AssetStore,
     texture_key: &TextureKey,
@@ -848,7 +848,7 @@ fn draw_texture(
     resolution: (usize, usize),
 ) {
     // Bump position up by half a unit then floor, for pixel snap
-    if _settings.pixel_snap {
+    if settings.pixel_snap {
         position = Vec2::new((position.x + 0.5).floor(), (position.y + 0.5).floor());
     }
 

--- a/src/rendering/render_settings.rs
+++ b/src/rendering/render_settings.rs
@@ -11,6 +11,7 @@ pub struct RenderSettings {
 
     // Whether or not the game engine should automatically cull sprites that are not in camera view
     pub frustrum_culling: bool,
+    pub pixel_snap: bool,
 }
 impl Default for RenderSettings {
     fn default() -> RenderSettings {
@@ -22,6 +23,7 @@ impl Default for RenderSettings {
             resizable_window: true,
             icon: None,
             frustrum_culling: true,
+            pixel_snap: true,
         }
     }
 }


### PR DESCRIPTION
Added ```pixel_snap``` render setting which is true by default.
Snaps the pixel value in ```fn draw_texture``` if true.

Addresses #174 