### PR TITLE
Add Actions to Input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ nalgebra =  { version = "0.31.0", features = ["convert-glam017"] }
 
 # Optionals
 rapier2d = { version = "0.12.0", optional = true  }
-gamepad = { version = "0.1.4", optional = true }
+gamepad = { version = "0.1.5", optional = true }
 asefile =  { version = "0.3.4", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Bombfuse <eiffeldud@gmail.com>"]
 edition = "2018"
 description = "A lite, fully featured 2D game engine."

--- a/examples/audio.rs
+++ b/examples/audio.rs
@@ -18,10 +18,8 @@ impl Game for Example {
     }
 
     fn update(&mut self, mut emd: Emerald) {
-        let mut input = emd.input();
-
         let volume = emd.audio().mixer("test").unwrap().get_volume().unwrap();
-        if input.is_key_just_pressed(KeyCode::A) {
+        if emd.input().is_key_just_pressed(KeyCode::A) {
             emd.audio()
                 .mixer("test")
                 .unwrap()
@@ -32,7 +30,7 @@ impl Game for Example {
                 .unwrap()
                 .set_volume(volume - 0.1)
                 .unwrap();
-        } else if input.is_key_just_pressed(KeyCode::D) {
+        } else if emd.input().is_key_just_pressed(KeyCode::D) {
             emd.audio()
                 .mixer("test")
                 .unwrap()
@@ -45,7 +43,7 @@ impl Game for Example {
                 .unwrap();
         }
 
-        if input.is_key_just_pressed(KeyCode::Space) {
+        if emd.input().is_key_just_pressed(KeyCode::Space) {
             let snd = emd.loader().sound("test_music.wav").unwrap();
             emd.audio()
                 .mixer("test")
@@ -54,7 +52,7 @@ impl Game for Example {
                 .unwrap();
         }
 
-        if input.is_key_just_pressed(KeyCode::Z) {
+        if emd.input().is_key_just_pressed(KeyCode::Z) {
             for _ in 0..10 {
                 let snd = emd.loader().sound("test_sound.wav").unwrap();
                 emd.audio()

--- a/examples/input_actions.rs
+++ b/examples/input_actions.rs
@@ -1,0 +1,45 @@
+use emerald::*;
+
+pub fn main() {
+    let mut settings = GameSettings::default();
+    let render_settings = RenderSettings {
+        resolution: (320 * 3, 180 * 3),
+        ..Default::default()
+    };
+    settings.render_settings = render_settings;
+    emerald::start(
+        Box::new(InputActionsExample {
+            world: World::new(),
+        }),
+        settings,
+    )
+}
+
+const ACTION_TEST: &str = "test_action";
+
+pub struct InputActionsExample {
+    world: World,
+}
+impl Game for InputActionsExample {
+    fn initialize(&mut self, mut emd: Emerald) {
+        emd.set_asset_folder_root(String::from("./examples/assets/"));
+        emd.input()
+            .add_action_binding_key(&ACTION_TEST.to_string(), KeyCode::A);
+        emd.input()
+            .add_action_binding_key(&ACTION_TEST.to_string(), KeyCode::P);
+        emd.input()
+            .add_action_binding_key(&ACTION_TEST.to_string(), KeyCode::G);
+    }
+
+    fn update(&mut self, mut emd: Emerald) {
+        if emd.input().is_action_just_pressed(&ACTION_TEST.to_string()) {
+            println!("Test Action Pressed");
+        }
+    }
+
+    fn draw(&mut self, mut emd: Emerald) {
+        emd.graphics().begin().ok();
+        emd.graphics().draw_world(&mut self.world).ok();
+        emd.graphics().render().ok();
+    }
+}

--- a/examples/render_to_texture.rs
+++ b/examples/render_to_texture.rs
@@ -38,9 +38,9 @@ impl Game for MyGame {
     }
 
     fn update(&mut self, mut emd: Emerald) {
-        let mut input = emd.input();
         let delta = emd.delta();
         let speed = 150.0;
+        let mut input = emd.input();
 
         if input.is_key_pressed(KeyCode::Left) {
             self.pos.translation.x -= speed * delta;

--- a/examples/touch.rs
+++ b/examples/touch.rs
@@ -26,19 +26,19 @@ impl Game for TouchExample {
 
     fn update(&mut self, mut emd: Emerald) {
         let input = emd.input();
-        let touches = input.touches();
+        let touches = input.touches().clone();
 
         let screen = emd.screen_size();
         let screen_center = Transform::from_translation((screen.0 / 2.0, screen.1 / 2.0));
 
-        for (&id, touch) in touches {
+        for (id, touch) in &touches {
             let bunny_position = touch.translation - screen_center.translation;
             if touch.is_just_pressed() {
                 let components: (Sprite, Transform) = (
                     self.sprite.clone().unwrap(),
                     Transform::from_translation(bunny_position),
                 );
-                self.bunnies.insert(id, self.world.spawn(components));
+                self.bunnies.insert(*id, self.world.spawn(components));
             } else if touch.is_just_released() {
                 if let Some(x) = self.bunnies.remove(&id) {
                     self.world.despawn(x).unwrap();

--- a/src/core.rs
+++ b/src/core.rs
@@ -141,6 +141,7 @@ impl<'c> Emerald<'c> {
     pub fn writer(&mut self) -> Writer {
         Writer::new(self.get_user_data_folder_root())
     }
+
     // ************************************* //
 
     // ************* Audio API ************* //
@@ -160,7 +161,7 @@ impl<'c> Emerald<'c> {
 
     // ************* Input API ************* //
     #[inline]
-    pub fn input(&mut self) -> InputHandler {
+    pub fn input(&mut self) -> InputHandler<'_> {
         InputHandler::new(self.input_engine)
     }
 

--- a/src/input/systems/ui_button.rs
+++ b/src/input/systems/ui_button.rs
@@ -9,9 +9,8 @@ use crate::{
 /// Updates the status of UI Buttons.
 /// Presses the button if the user has pressed it, etc...
 pub fn ui_button_system(emd: &mut Emerald<'_>, world: &mut World) {
-    let input = emd.input();
-    let mouse = input.mouse();
-    let touches = input.touches();
+    let mouse = emd.input().mouse();
+    let touches = emd.input().touches().clone();
     let screen_size = emd.screen_size();
     let mouse_position = screen_translation_to_world_translation(
         (screen_size.0 as u32, screen_size.1 as u32),
@@ -35,7 +34,7 @@ pub fn ui_button_system(emd: &mut Emerald<'_>, world: &mut World) {
             is_translation_inside_button(emd, &ui_button, &transform, &mouse_position)
                 || check_touches_overlap_button(
                     emd,
-                    touches,
+                    &touches,
                     &touch_world_positions,
                     &ui_button,
                     &transform,


### PR DESCRIPTION
Very manual API for now, adding/removing keys and buttons to an action directly.

Added an example on how to use it as well, the example is very basic and only prints to the terminal.

Unfortunately there is a breaking change, that ties the InputHandler to the Emerald struct directly. However, I think this is for the best, as the user's bindings need to be stored longterm.