### PR TITLE
add resources to World and Emerald

### DIFF
--- a/emerald/Cargo.toml
+++ b/emerald/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald"
-version = "0.3.205"
+version = "0.3.206"
 authors = ["Bombfuse <eiffeldud@gmail.com>"]
 edition = "2018"
 description = "A lite, fully featured 2D game engine."
@@ -33,6 +33,7 @@ bytemuck = { version = "1.12.1", features = ["derive"] }
 gamepad = { version = "0.1.5", optional = true }
 asefile =  { version = "0.3.4", optional = true }
 emd_earcutr = "0.1.0"
+anymap = { version = "0.12.1", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 kira = { version= "0.5.3", optional = true, default-features = false, features = ["ogg", "flac", "wav"] }

--- a/emerald/src/core.rs
+++ b/emerald/src/core.rs
@@ -33,6 +33,7 @@ pub struct Emerald<'c> {
     pub(crate) asset_store: &'c mut AssetStore,
     profile_cache: &'c mut ProfileCache,
     ctx: &'c mut GameEngineContext,
+    resources: &'c mut anymap::AnyMap,
 }
 impl<'c> Emerald<'c> {
     #[inline]
@@ -46,6 +47,7 @@ impl<'c> Emerald<'c> {
         asset_store: &'c mut AssetStore,
         profile_cache: &'c mut ProfileCache,
         ctx: &'c mut GameEngineContext,
+        resources: &'c mut anymap::AnyMap,
     ) -> Self {
         Emerald {
             delta,
@@ -57,6 +59,7 @@ impl<'c> Emerald<'c> {
             asset_store,
             profile_cache,
             ctx,
+            resources,
         }
     }
 
@@ -169,6 +172,11 @@ impl<'c> Emerald<'c> {
         &mut self.logging_engine
     }
     // ************************************* //
+
+    #[inline]
+    pub fn resources(&mut self) -> &mut anymap::AnyMap {
+        &mut self.resources
+    }
 
     // ************* Input API ************* //
     #[inline]

--- a/emerald/src/core/game_engine.rs
+++ b/emerald/src/core/game_engine.rs
@@ -6,8 +6,9 @@ use winit::{
 };
 
 use crate::{
-    profiling::profile_cache::ProfileCache, rendering_engine::RenderingEngine, AssetStore,
-    AudioEngine, Emerald, EmeraldError, Game, GameSettings, InputEngine, LoggingEngine,
+    profiling::profile_cache::ProfileCache, rendering_engine::RenderingEngine,
+    resources::Resources, AssetStore, AudioEngine, Emerald, EmeraldError, Game, GameSettings,
+    InputEngine, LoggingEngine,
 };
 
 pub(crate) struct GameEngineContext {
@@ -28,6 +29,7 @@ pub(crate) struct GameEngine {
     input_engine: InputEngine,
     asset_store: AssetStore,
     logging_engine: LoggingEngine,
+    resources: Resources,
 
     last_instant: f64,
     fps_tracker: VecDeque<f64>,
@@ -62,6 +64,7 @@ impl GameEngine {
             profile_cache,
             last_instant: date::now(),
             fps_tracker,
+            resources: Resources::new(),
         })
     }
 
@@ -80,6 +83,7 @@ impl GameEngine {
             &mut self.asset_store,
             &mut self.profile_cache,
             ctx,
+            &mut self.resources,
         );
 
         self.game.initialize(emd);
@@ -128,6 +132,7 @@ impl GameEngine {
             &mut self.asset_store,
             &mut self.profile_cache,
             ctx,
+            &mut self.resources,
         );
 
         self.game.update(emd);
@@ -152,6 +157,7 @@ impl GameEngine {
             &mut self.asset_store,
             &mut self.profile_cache,
             ctx,
+            &mut self.resources,
         );
         self.game.draw(emd);
         // self.rendering_engine.post_draw(ctx, &mut self.asset_store);
@@ -170,183 +176,6 @@ impl GameEngine {
         self.fps_tracker.push_back(delta);
     }
 }
-
-// use miniquad::Context;
-// use miniquad::EventHandler;
-// use miniquad::KeyMods;
-
-// use crate::assets::*;
-// use crate::audio::*;
-// use crate::core::*;
-// use crate::input::*;
-// use crate::logging::*;
-// use crate::rendering::*;
-
-// use std::collections::VecDeque;
-
-// pub struct GameEngine {
-//     game: Box<dyn Game>,
-//     _settings: GameSettings,
-//     audio_engine: AudioEngine,
-//     input_engine: InputEngine,
-//     logging_engine: LoggingEngine,
-//     rendering_engine: RenderingEngine,
-//     last_instant: f64,
-//     fps_tracker: VecDeque<f64>,
-//     asset_store: AssetStore,
-//     profile_cache: ProfileCache,
-// }
-// impl<'c> GameEngine {
-//     pub fn new(mut game: Box<dyn Game>, settings: GameSettings, mut ctx: &mut Context) -> Self {
-//         let mut asset_store = AssetStore::new(ctx, settings.title.clone()).unwrap();
-//         let mut logging_engine = LoggingEngine::new();
-//         let mut audio_engine = AudioEngine::new();
-//         let mut input_engine = InputEngine::new();
-//         let mut rendering_engine =
-//             RenderingEngine::new(&mut ctx, settings.render_settings.clone(), &mut asset_store);
-
-//         let mut profile_cache = ProfileCache::new(Default::default());
-
-//         let delta = 0.0;
-//         let starting_amount = 50;
-//         let mut fps_tracker = VecDeque::with_capacity(starting_amount);
-//         fps_tracker.resize(starting_amount, 1.0 / 60.0);
-//         let last_instant = miniquad::date::now();
-
-//         let emd = Emerald::new(
-//             delta,
-//             0.0,
-//             &mut ctx,
-//             &mut audio_engine,
-//             &mut input_engine,
-//             &mut logging_engine,
-//             &mut rendering_engine,
-//             &mut asset_store,
-//             &mut profile_cache,
-//         );
-
-//         game.initialize(emd);
-
-//         GameEngine {
-//             game,
-//             fps_tracker,
-//             _settings: settings,
-//             audio_engine,
-//             input_engine,
-//             logging_engine,
-//             rendering_engine,
-//             last_instant,
-//             asset_store,
-//             profile_cache,
-//         }
-//     }
-
-//     /// Return frame rate averaged out over last N frames
-//     /// https://github.com/17cupsofcoffee/tetra/blob/master/src/time.rs
-//     #[inline]
-//     pub fn get_fps(&self) -> f64 {
-//         1.0 / (self.fps_tracker.iter().sum::<f64>() / self.fps_tracker.len() as f64)
-//     }
-
-//     #[inline]
-//     fn update_fps_tracker(&mut self, delta: f64) {
-//         self.fps_tracker.pop_front();
-//         self.fps_tracker.push_back(delta);
-//     }
-// }
-// impl<'a, 'b> EventHandler for GameEngine {
-//     #[inline]
-//     fn update(&mut self, mut ctx: &mut Context) {
-//         let start_of_frame = miniquad::date::now();
-//         let delta = start_of_frame - self.last_instant;
-//         self.last_instant = start_of_frame;
-
-//         self.update_fps_tracker(delta);
-
-//         let emd = Emerald::new(
-//             delta as f32,
-//             self.get_fps(),
-//             &mut ctx,
-//             &mut self.audio_engine,
-//             &mut self.input_engine,
-//             &mut self.logging_engine,
-//             &mut self.rendering_engine,
-//             &mut self.asset_store,
-//             &mut self.profile_cache,
-//         );
-
-//         self.game.update(emd);
-//         self.logging_engine.update().unwrap();
-//         self.input_engine.update_and_rollover().unwrap();
-//         self.audio_engine.post_update().unwrap();
-//     }
-
-//     #[inline]
-//     fn key_down_event(
-//         &mut self,
-//         _ctx: &mut Context,
-//         keycode: KeyCode,
-//         _keymods: KeyMods,
-//         repeat: bool,
-//     ) {
-//         self.input_engine.set_key_down(keycode, repeat);
-//     }
-
-//     #[inline]
-//     fn key_up_event(&mut self, _ctx: &mut Context, keycode: KeyCode, _keymods: KeyMods) {
-//         self.input_engine.set_key_up(keycode);
-//     }
-
-//     #[inline]
-//     fn mouse_motion_event(&mut self, ctx: &mut Context, x: f32, y: f32) {
-//         let y = ctx.screen_size().1 - y;
-//         self.input_engine.set_mouse_translation(x, y)
-//     }
-
-//     #[inline]
-//     fn mouse_button_down_event(&mut self, ctx: &mut Context, button: MouseButton, x: f32, y: f32) {
-//         let y = ctx.screen_size().1 - y;
-//         self.input_engine.set_mouse_down(button, x, y)
-//     }
-
-//     #[inline]
-//     fn mouse_button_up_event(&mut self, ctx: &mut Context, button: MouseButton, x: f32, y: f32) {
-//         let y = ctx.screen_size().1 - y;
-//         self.input_engine.set_mouse_up(button, x, y)
-//     }
-
-//     #[inline]
-//     fn touch_event(&mut self, ctx: &mut Context, phase: TouchPhase, id: u64, x: f32, y: f32) {
-//         let y = ctx.screen_size().1 - y;
-//         self.input_engine.touch_event(phase, id, x, y)
-//     }
-
-//     #[inline]
-//     fn draw(&mut self, mut ctx: &mut Context) {
-//         let start_of_frame = miniquad::date::now();
-//         let delta = start_of_frame - self.last_instant;
-
-//         self.rendering_engine
-//             .pre_draw(ctx, &mut self.asset_store)
-//             .unwrap();
-//         let emd = Emerald::new(
-//             delta as f32,
-//             self.get_fps(),
-//             &mut ctx,
-//             &mut self.audio_engine,
-//             &mut self.input_engine,
-//             &mut self.logging_engine,
-//             &mut self.rendering_engine,
-//             &mut self.asset_store,
-//             &mut self.profile_cache,
-//         );
-
-//         self.game.draw(emd);
-//         ctx.commit_frame();
-
-//         self.rendering_engine.post_draw(ctx, &mut self.asset_store);
-//     }
-// }
 
 pub(crate) mod date {
     pub fn now() -> f64 {

--- a/emerald/src/input/input_engine.rs
+++ b/emerald/src/input/input_engine.rs
@@ -7,7 +7,6 @@ use winit::event::{ElementState, VirtualKeyCode};
 use std::collections::{HashMap, HashSet};
 
 use super::touch_state::TouchState;
-
 pub(crate) struct Action {
     pub key_bindings: HashSet<KeyCode>,
     #[cfg(feature = "gamepads")]

--- a/emerald/src/lib.rs
+++ b/emerald/src/lib.rs
@@ -8,6 +8,7 @@ pub mod input;
 pub mod logging;
 pub mod profiling;
 pub mod rendering;
+pub mod resources;
 pub mod types;
 pub mod world;
 

--- a/emerald/src/resources.rs
+++ b/emerald/src/resources.rs
@@ -1,0 +1,1 @@
+pub type Resources = anymap::AnyMap;


### PR DESCRIPTION
Let the user define custom resources to be stored in the World and in the Emerald itself.

Storing resources in the Emerald context will make creating plugins easier, as third party libraries can manage everything they need with the primary game context.

Another example, that I plan on using it for is storing data such as narrative text without needing to pass around more structs/configs to various places.

Storing resources in the World can be used for holding some game state, generally this is discouraged but it allows more user choice so I added it in.