### PR TITLE
ignore outdated texture renders

### DIFF
--- a/emerald/Cargo.toml
+++ b/emerald/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "emerald"
-version = "0.3.207"
+version = "0.3.208"
 authors = ["Bombfuse <eiffeldud@gmail.com>"]
 edition = "2018"
 description = "A lite, fully featured 2D game engine."

--- a/emerald/src/rendering/rendering_engine.rs
+++ b/emerald/src/rendering/rendering_engine.rs
@@ -520,6 +520,7 @@ impl RenderingEngine {
             Err(e) => {
                 match e {
                     wgpu::SurfaceError::Lost => self.resize_window(self.size),
+                    wgpu::SurfaceError::Outdated => return Ok(()),
                     _ => {}
                 };
                 Err(EmeraldError::new(format!("{:?}", e)))

--- a/emerald/src/rendering/rendering_engine.rs
+++ b/emerald/src/rendering/rendering_engine.rs
@@ -520,6 +520,7 @@ impl RenderingEngine {
             Err(e) => {
                 match e {
                     wgpu::SurfaceError::Lost => self.resize_window(self.size),
+                    // outdated surface texture, no point rendering to it, just skip
                     wgpu::SurfaceError::Outdated => return Ok(()),
                     _ => {}
                 };


### PR DESCRIPTION
fix crash on windows 10 when the game window is resized by user to be 0px width/height