### PR TITLE
Quick SoundPlayer component implementation

### DIFF
--- a/emerald/examples/audio.rs
+++ b/emerald/examples/audio.rs
@@ -1,4 +1,7 @@
-use emerald::{render_settings::RenderSettings, rendering::components::Label, *};
+use emerald::{
+    audio::components::sound_player::SoundPlayer, render_settings::RenderSettings,
+    rendering::components::Label, *,
+};
 
 /// Music found from https://opengameart.org/content/5-chiptunes-action
 pub fn main() {
@@ -7,13 +10,24 @@ pub fn main() {
         ..Default::default()
     };
     settings.render_settings = render_settings;
-    emerald::start(Box::new(Example {}), settings)
+    emerald::start(
+        Box::new(Example {
+            world: World::new(),
+        }),
+        settings,
+    )
 }
 
-pub struct Example {}
+pub struct Example {
+    world: World,
+}
 impl Game for Example {
     fn initialize(&mut self, mut emd: Emerald) {
         emd.set_asset_folder_root(String::from("./examples/assets/"));
+
+        let mut sound_player = SoundPlayer::new("sfx");
+        sound_player.add_sound("test", emd.loader().sound("test_sound.wav").unwrap());
+        self.world.spawn((sound_player,));
     }
 
     fn update(&mut self, mut emd: Emerald) {
@@ -40,6 +54,12 @@ impl Game for Example {
                 .unwrap()
                 .set_volume(volume + 0.1)
                 .unwrap();
+        }
+
+        if emd.input().is_key_just_pressed(KeyCode::C) {
+            for (_, player) in self.world.query::<&SoundPlayer>().iter() {
+                player.play(&mut emd, "test").unwrap();
+            }
         }
 
         if emd.input().is_key_just_pressed(KeyCode::Space) {

--- a/emerald/src/assets/asset_engine.rs
+++ b/emerald/src/assets/asset_engine.rs
@@ -193,6 +193,8 @@ impl AssetEngine {
         for id in to_remove {
             self.asset_stores.remove(&id);
         }
+        println!("sound count {:?}", self.count::<Sound>());
+        println!("texture count {:?}", self.count::<Texture>());
 
         Ok(())
     }

--- a/emerald/src/assets/asset_engine.rs
+++ b/emerald/src/assets/asset_engine.rs
@@ -194,9 +194,6 @@ impl AssetEngine {
             self.asset_stores.remove(&id);
         }
 
-        println!("sound count {:?}", self.count::<Sound>());
-        println!("texture count {:?}", self.count::<Texture>());
-
         Ok(())
     }
 }

--- a/emerald/src/assets/asset_loader.rs
+++ b/emerald/src/assets/asset_loader.rs
@@ -1,5 +1,3 @@
-use wgpu::BindGroupLayout;
-
 use crate::asset_key::AssetKey;
 use crate::assets::*;
 use crate::audio::*;
@@ -10,7 +8,6 @@ use crate::font::FontKey;
 use crate::rendering::components::Sprite;
 use crate::rendering_engine::RenderingEngine;
 use crate::texture::get_texture_key;
-use crate::texture::Texture;
 use crate::texture::TextureKey;
 use crate::*;
 

--- a/emerald/src/audio.rs
+++ b/emerald/src/audio.rs
@@ -1,4 +1,4 @@
-mod components;
+pub mod components;
 mod engine;
 mod handler;
 mod mixer;

--- a/emerald/src/audio.rs
+++ b/emerald/src/audio.rs
@@ -1,3 +1,4 @@
+mod components;
 mod engine;
 mod handler;
 mod mixer;

--- a/emerald/src/audio/components.rs
+++ b/emerald/src/audio/components.rs
@@ -1,0 +1,1 @@
+pub mod sound_player;

--- a/emerald/src/audio/components/sound_player.rs
+++ b/emerald/src/audio/components/sound_player.rs
@@ -1,4 +1,4 @@
-use std::{cell::Ref, collections::HashMap};
+use std::collections::HashMap;
 
 use crate::{Emerald, EmeraldError, SoundInstanceId, SoundKey};
 
@@ -14,6 +14,10 @@ impl SoundPlayer {
             mixer: mixer.into(),
             keys: HashMap::new(),
         }
+    }
+
+    pub fn add_sound(&mut self, label: &str, key: SoundKey) {
+        self.keys.insert(label.to_string(), key);
     }
 
     pub fn play(&self, emd: &mut Emerald, label: &str) -> Result<SoundInstanceId, EmeraldError> {

--- a/emerald/src/audio/components/sound_player.rs
+++ b/emerald/src/audio/components/sound_player.rs
@@ -1,0 +1,30 @@
+use std::{cell::Ref, collections::HashMap};
+
+use crate::{Emerald, EmeraldError, SoundInstanceId, SoundKey};
+
+/// Holds sound keys and can play them given Emerald.
+/// Mostly useful for preloading the sounds needed by Entities, or the World.
+pub struct SoundPlayer {
+    keys: HashMap<String, SoundKey>,
+    mixer: String,
+}
+impl SoundPlayer {
+    pub fn new<T: Into<String>>(mixer: T) -> Self {
+        Self {
+            mixer: mixer.into(),
+            keys: HashMap::new(),
+        }
+    }
+
+    pub fn play(&self, emd: &mut Emerald, label: &str) -> Result<SoundInstanceId, EmeraldError> {
+        if let Some(key) = self.keys.get(label) {
+            let id = emd.audio().mixer(&self.mixer)?.play(key)?;
+            return Ok(id);
+        }
+
+        Err(EmeraldError::new(format!(
+            "{:?} is not loaded into the Sound Player",
+            label
+        )))
+    }
+}

--- a/emerald/src/world/ent.rs
+++ b/emerald/src/world/ent.rs
@@ -8,7 +8,8 @@ use crate::{
 
 use self::{
     ent_color_rect_loader::load_ent_color_rect, ent_label_loader::load_ent_label,
-    ent_sprite_loader::load_ent_sprite, ent_transform_loader::load_ent_transform,
+    ent_sound_player_loader::SOUND_PLAYER_SCHEMA_KEY, ent_sprite_loader::load_ent_sprite,
+    ent_transform_loader::load_ent_transform,
 };
 #[cfg(feature = "aseprite")]
 pub(crate) mod ent_aseprite_loader;
@@ -16,6 +17,7 @@ pub(crate) mod ent_aseprite_loader;
 pub(crate) mod ent_color_rect_loader;
 pub(crate) mod ent_label_loader;
 pub(crate) mod ent_rigid_body_loader;
+pub(crate) mod ent_sound_player_loader;
 pub(crate) mod ent_sprite_loader;
 pub(crate) mod ent_transform_loader;
 
@@ -78,6 +80,13 @@ pub(crate) fn load_ent(
                 SPRITE_SCHEMA_KEY => {
                     if let Some(sprite_value) = table.remove(SPRITE_SCHEMA_KEY) {
                         load_ent_sprite(loader, entity, world, &sprite_value)?;
+                    }
+                }
+                SOUND_PLAYER_SCHEMA_KEY => {
+                    if let Some(value) = table.remove(SOUND_PLAYER_SCHEMA_KEY) {
+                        ent_sound_player_loader::load_ent_sound_player(
+                            loader, entity, world, &value,
+                        )?;
                     }
                 }
                 RIGID_BODY_SCHEMA_KEY => {

--- a/emerald/src/world/ent/ent_sound_player_loader.rs
+++ b/emerald/src/world/ent/ent_sound_player_loader.rs
@@ -1,0 +1,48 @@
+use hecs::Entity;
+use serde::{Deserialize, Serialize};
+
+use crate::{audio::components::sound_player::SoundPlayer, AssetLoader, EmeraldError, World};
+
+use super::Vec2f32Schema;
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct EntSoundSchema {
+    /// Label for the sound key
+    pub label: String,
+
+    /// Path to the sound file
+    pub sound: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct EntSoundPlayerSchema {
+    sounds: Vec<EntSoundSchema>,
+    mixer: String,
+}
+
+pub const SOUND_PLAYER_SCHEMA_KEY: &str = "sound_player";
+
+pub(crate) fn load_ent_sound_player<'a>(
+    loader: &mut AssetLoader<'a>,
+    entity: Entity,
+    world: &mut World,
+    toml: &toml::Value,
+) -> Result<(), EmeraldError> {
+    if !toml.is_table() {
+        return Err(EmeraldError::new(
+            "Cannot load sprite from a non-table toml value.",
+        ));
+    }
+
+    let schema: EntSoundPlayerSchema = toml::from_str(&toml.to_string())?;
+    let mut sound_player = SoundPlayer::new(schema.mixer);
+
+    for sound_schema in schema.sounds {
+        let key = loader.sound(sound_schema.sound)?;
+        sound_player.add_sound(&sound_schema.label, key);
+    }
+
+    world.insert_one(entity, sound_player)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Utilizing sound players in your world/ent files should preload the audio and drop them automatically when necessary.