### PR TITLE
[Proposal] - Tilemap serialization

### DIFF
--- a/emerald/examples/tilemap.rs
+++ b/emerald/examples/tilemap.rs
@@ -1,4 +1,4 @@
-use emerald::{tilemap::Tilemap, *};
+use emerald::{tilemap::Tilemap, tilemap::TilemapSchema, *};
 
 pub fn main() {
     emerald::start(
@@ -23,7 +23,14 @@ impl Game for TilemapExample {
         tilemap.set_tile(0, 1, Some(2)).unwrap();
         tilemap.set_tile(1, 1, Some(3)).unwrap();
 
-        self.world.spawn((tilemap, Transform::default()));
+        //This is how you serialize/deserialize a tilemap:
+        let serialized_schema = toml::to_string(&tilemap).unwrap();
+        let deserialized_schema: TilemapSchema = toml::from_str(&serialized_schema).unwrap();
+        let deserialized_tilemap: Tilemap =
+            deserialized_schema.to_tilemap(&mut emd.loader()).unwrap();
+
+        self.world
+            .spawn((deserialized_tilemap, Transform::default()));
     }
 
     fn update(&mut self, _emd: Emerald) {}


### PR DESCRIPTION
This is an initial proposal based on #251 discussion for how we could serialize/deserialize a `Tilemap` via `TilemapSchema` conversions.

Pros:
- Enables users to serialize/deserialize a tilemap.
- Serialization/deserialization works organically as `serde` and `toml` users would expect. 

Cons:
- Requires making `TilemapSchema` public. Meaning that if we go forward with this approach, we would have to do the same to other components such as `Autotilemap` and `AutoTilemapSchema`.
- Actually converts a `Tilemap` into a `TilemapSchema`.

Obs: I didn't add any `#[test]` as doing so would require loading the engine and actually creating a tilemap (with a tileset and everything), that's why I opted to put the test in the `emerald/examples/tilemap.rs`. 